### PR TITLE
Fixed issue with g:godown_autorun being undefined

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,5 +1,5 @@
 augroup godown
-	if g:godown_autorun
+	if get(g:, 'godown_autorun', 0)
 		autocmd! BufWinEnter <buffer> GodownPreview
 	endif
 	autocmd! BufWinLeave <buffer> GodownClean


### PR DESCRIPTION
Before:

    Error detected while processing ~/.vim/plugged/godown-vim/ftplugin/markdown.vim:
    line    2:
    E121: Undefined variable: g:godown_autorun
    E15: Invalid expression: g:godown_autorun
    Press ENTER or type command to continue

After:

    No issue